### PR TITLE
fix relative pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Run the following command to start the program
 python src/main.py --config var/config.yml
 ```
 
+Note: If you don't provide the `--config` option the app will look for the config path `var/config.yml`
+relative to the current working directory.
+
 #### Verify your output
 Navigate to your Lattice UI and verify that the vessel entities are displayed.
 

--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="AIS Vessel to Lattice Mesh Integration")
     parser.add_argument(
-        "--config", action="store", dest="configpath", default="../var/config.yml"
+        "--config", action="store", dest="configpath", default="var/config.yml"
     )
     args = parser.parse_args()
 

--- a/var/config.yml
+++ b/var/config.yml
@@ -1,7 +1,7 @@
 # lattice dns/ip
-lattice-ip: <YOUR_LATTICE_IP>
+lattice-ip: $YOUR_LATTICE_URL
 # lattice-bearer-token
-lattice-bearer-token: <YOUR_LATTICE_BEARER_TOKEN>
+lattice-bearer-token: $YOUR_BEARER_TOKEN
 # entity update frequency (seconds)
 entity-update-rate-seconds: 1
 # vessels to track


### PR DESCRIPTION
If the `--config` option is not presented then the app would try to find the config at `../var/config`. Since the README says to run from the repo root, this resulted in a runtime error.

Corrected to search for `var` from current working directory instead.